### PR TITLE
Add mTLS authentication support

### DIFF
--- a/temporal/service_helpers.py
+++ b/temporal/service_helpers.py
@@ -1,13 +1,42 @@
 import os
 import socket
+import ssl
+from typing import List
 
+from dataclasses import dataclass, field
 from grpclib.client import Channel
 
 from temporal.api.workflowservice.v1 import WorkflowServiceStub
 
 
-def create_workflow_service(host: str, port: int, timeout: float) -> WorkflowServiceStub:
-    channel = Channel(host=host, port=port)
+@dataclass
+class TLSOptions:
+    alpn_protocols: List = field(default_factory=lambda: ['h2'])
+    ca_cert: str = None
+    client_cert: str = None
+    client_key: str = None
+    ciphers: str = "ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20"
+    npn_protocols: List = field(default_factory=lambda: ['h2'])
+
+
+def create_secure_context(tls_options: TLSOptions) -> ssl.SSLContext:
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.load_cert_chain(str(tls_options.client_cert), str(tls_options.client_key))
+    ctx.load_verify_locations(str(tls_options.ca_cert))
+    ctx.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+    ctx.set_ciphers(tls_options.ciphers)
+    ctx.set_alpn_protocols(tls_options.alpn_protocols)
+    try:
+        ctx.set_npn_protocols(tls_options.npn_protocols)
+    except NotImplementedError:
+        pass
+    return ctx
+
+
+def create_workflow_service(host: str, port: int, timeout: float, tls_options: TLSOptions) -> WorkflowServiceStub:
+    ssl_context = create_secure_context(tls_options) if tls_options is not None else None
+    channel = Channel(host=host, port=port, ssl=ssl_context)
     return WorkflowServiceStub(channel, timeout=timeout)
 
 

--- a/temporal/workflow.py
+++ b/temporal/workflow.py
@@ -25,7 +25,7 @@ from .errors import QueryFailedError
 from .exception_handling import deserialize_exception
 from .exceptions import WorkflowFailureException, ActivityFailureException, QueryRejectedException, \
     QueryFailureException, WorkflowOperationException
-from .service_helpers import create_workflow_service, get_identity
+from .service_helpers import create_workflow_service, get_identity, TLSOptions
 
 
 T = TypeVar('T')
@@ -157,8 +157,9 @@ class WorkflowClient:
     @classmethod
     def new_client(cls, host: str = "localhost", port: int = 7233, namespace: str = "",
                    options: WorkflowClientOptions = None, timeout: int = DEFAULT_SOCKET_TIMEOUT_SECONDS,
-                   data_converter: DataConverter = DEFAULT_DATA_CONVERTER_INSTANCE) -> WorkflowClient:
-        service = create_workflow_service(host, port, timeout=timeout)
+                   data_converter: DataConverter = DEFAULT_DATA_CONVERTER_INSTANCE,
+                   tls_options: TLSOptions = None) -> WorkflowClient:
+        service = create_workflow_service(host, port, timeout=timeout, tls_options=tls_options)
         return cls(service=service, namespace=namespace, options=options, data_converter=data_converter)
 
     @classmethod


### PR DESCRIPTION
Adds support for specifying TLS options for mTLS authentication during workflow client creation.

Tested against mTLS-enabled server @ 1.10.5 and mTLS-disabled server @ 1.7.0.

For SSLContext reference, see [grpclib mTLS client example](https://github.com/vmagamedov/grpclib/blob/master/examples/mtls/client.py) 

Related to #7

Changes:

- Adds `TLSOptions` dataclass
- Adds `tls_options` kwarg to `WorkflowClient.new_client` method
- If `TLSOptions` provided, creates `SSLContext`
- If `SSLContext` created, provides `SSLContext` to `grcplib.client.Channel`

Minimal config example:

```python
from temporal.service_helpers import TLSOptions
from temporal.workflow import WorkflowClient

client = WorkflowClient.new_client(
    host="temporal.local",
    port=7233,
    tls_options=TLSOptions(
        ca_cert="/path/to/ca-cert",
        client_cert="/path/to/client-cert",
        client_key="/path/to/client-key",
    )
)
```